### PR TITLE
Introducing max-toc-level parameter to control the sidebar toc depth..

### DIFF
--- a/src/darkslide/cli.py
+++ b/src/darkslide/cli.py
@@ -64,6 +64,13 @@ def _parse_options():
     )
 
     parser.add_option(
+        "-m", "--max-toc-level",
+        type="int",
+        dest="maxtoclevel",
+        help="Limits the TOC level generation to a specific level.",
+        default=9)
+
+    parser.add_option(
         "-o", "--direct-output",
         action="store_true",
         dest="direct",

--- a/src/darkslide/cli.py
+++ b/src/darkslide/cli.py
@@ -68,7 +68,7 @@ def _parse_options():
         type="int",
         dest="maxtoclevel",
         help="Limits the TOC level generation to a specific level.",
-        default=9)
+        default=2)
 
     parser.add_option(
         "-o", "--direct-output",

--- a/src/darkslide/generator.py
+++ b/src/darkslide/generator.py
@@ -18,7 +18,6 @@ from .parser import Parser
 
 BASE_DIR = os.path.dirname(__file__)
 THEMES_DIR = os.path.join(BASE_DIR, 'themes')
-TOC_MAX_LEVEL = 2
 VALID_LINENOS = ('no', 'inline', 'table')
 
 
@@ -50,6 +49,7 @@ class Generator(object):
             - ``encoding``: the encoding to use for this presentation
             - ``extensions``: Comma separated list of markdown extensions
             - ``logger``: a logger lambda to use for logging
+            - ``maxtoclevel``: the maximum level to include in toc
             - ``presenter_notes``: enable presenter notes
             - ``relative``: enable relative asset urls
             - ``theme``: path to the theme to use for this presentation
@@ -66,6 +66,7 @@ class Generator(object):
         self.encoding = kwargs.get('encoding', 'utf8')
         self.extensions = kwargs.get('extensions', None)
         self.logger = kwargs.get('logger', None)
+        self.maxtoclevel = kwargs.get('maxtoclevel', 2)
         self.presenter_notes = kwargs.get('presenter_notes', True)
         self.relative = kwargs.get('relative', False)
         self.theme = kwargs.get('theme', 'default')
@@ -94,6 +95,7 @@ class Generator(object):
             self.relative = config.get('relative', self.relative)
             self.copy_theme = config.get('copy_theme', self.copy_theme)
             self.extensions = config.get('extensions', self.extensions)
+            self.maxtoclevel = config.get('max-toc-level', self.maxtoclevel)
             self.theme = config.get('theme', self.theme)
             self.destination_dir = os.path.dirname(self.destination_file)
             self.add_user_css(config.get('css', []))
@@ -422,12 +424,13 @@ class Generator(object):
                 continue
             self.num_slides += 1
             slide_number = slide_vars['number'] = self.num_slides
-            if slide_vars['level'] and slide_vars['level'] <= TOC_MAX_LEVEL:
-                self.add_toc_entry(slide_vars['title'], slide_vars['level'],
-                                   slide_number)
+            if slide_vars['level'] and slide_vars['level'] <= self.maxtoclevel:
+                self.add_toc_entry(slide_vars['title'], slide_vars['level'], slide_number)
             else:
                 # Put something in the TOC even if it doesn't have a title or level
-                self.add_toc_entry(u"-", 1, slide_number)
+                # self.add_toc_entry(u"-", 1, slide_number)
+                # No way: nothing to add in the TOC in this case !
+                pass
 
         return {'head_title': head_title, 'num_slides': str(self.num_slides),
                 'slides': slides, 'toc': self.toc, 'embed': self.embed,
@@ -469,6 +472,8 @@ class Generator(object):
             config['destination'] = raw_config.get(section_name, 'destination')
         if raw_config.has_option(section_name, 'linenos'):
             config['linenos'] = raw_config.get(section_name, 'linenos')
+        if raw_config.has_option(section_name, 'max-toc-level'):
+            config['max-toc-level'] = int(raw_config.get(section_name, 'max-toc-level'))
         for boolopt in ('embed', 'relative', 'copy_theme'):
             if raw_config.has_option(section_name, boolopt):
                 config[boolopt] = raw_config.getboolean(section_name, boolopt)

--- a/src/darkslide/themes/default/base.html
+++ b/src/darkslide/themes/default/base.html
@@ -124,18 +124,34 @@
     <h2>Table of Contents</h2>
     <table>
       <caption>Table of Contents</caption>
+
+<!-- macro for generating subsection of TOC -->
+{% macro subtoc(section) -%} 
+{{ caller() }}
+        {% for subsection in section.sub %}
+        <tr id="toc-row-{{ subsection.number }}" class="sub">
+          <th><a href="#slide:{{ subsection.number }}">{{ subsection.title }}</a></th>
+          <td><a href="#slide:{{ subsection.number }}">{{ subsection.number }}</a></td>
+        </tr>
+        {% if subsection.sub %}
+           <!-- generating recursively subsections of TOC -->
+           {% call subtoc(subsection) %}
+           {% endcall %}
+        {% endif %}
+        {% endfor %}
+{%- endmacro %}
+<!-- end of macro -->
+
+      <!-- generating sections of TOC -->
       {% for section in toc %}
       <tr id="toc-row-{{ section.number }}">
         <th><a href="#slide:{{ section.number }}">{{ section.title }}</a></th>
         <td><a href="#slide:{{ section.number }}">{{ section.number }}</a></td>
       </tr>
       {% if section.sub %}
-        {% for subsection in section.sub %}
-        <tr id="toc-row-{{ subsection.number }}" class="sub">
-          <th><a href="#slide:{{ subsection.number }}">{{ subsection.title }}</a></th>
-          <td><a href="#slide:{{ subsection.number }}">{{ subsection.number }}</a></td>
-        </tr>
-        {% endfor %}
+         <!-- generating subsections of TOC -->
+         {% call subtoc(section) %}
+         {% endcall %}
       {% endif %}
       {% endfor %}
     </table>


### PR DESCRIPTION
I have a working code for TOC with any depth.
- the parser of the CLI takes a new parameter (also works with a config file)
- the generator checks this level before inserting the entry in the TOC
- the jinja2 template contains a new macro :)
  - the macro defines the loop for generating a subsection array
  - at the end, if the array contains a "sub" elements, the macro is recalled recursivelly
- I have disabled the phantom entry when no title is given (it gave me an error on my 100+ slides)

I have to work to another issue: entries in the TOC with a number have a wrong backref: #slide:NaN.

First time I build a pull request from a branch I did. I hope all is ok :)