### PR TITLE
Fix the TOC when a local TOC is generated on a slide.

### DIFF
--- a/examples/markdown/slides.md
+++ b/examples/markdown/slides.md
@@ -119,6 +119,28 @@ Hello from presenter notes
 
 ---
 
+# TOC and subsections
+
+A presentation supports multiple section levels. Subsections can be used to organize contents.
+
+The global TOC includes sections and subsections.
+
+The max-toc-level parameter allows the user to limit the number of subsections included in the global TOC.
+
+---
+
+## Subsection A
+
+This slide is a subsection of the section "Toc and subsections"
+
+---
+
+## Subsection B
+
+This slide is a subsection of the section "Toc and subsections"
+
+---
+
 # Other features
 
 View other features in the help sidebar by pressing `h`

--- a/examples/restructuredtext/slides.rst
+++ b/examples/restructuredtext/slides.rst
@@ -143,7 +143,45 @@ Hello from presenter notes
 
 ----
 
+TOC and subsections
+===================
+
+A presentation supports multiple section levels. Subsections can be used to organize contents and generate local table of contents.
+
+A table of content with depth 1:
+
+.. contents::
+   :local:
+   :depth: 1
+
+----
+
+Subsection A
+------------
+
+This slide is a subsection of the section "Toc and subsections"
+
+----
+
+Subsection B
+------------
+
+This slide is a subsection of the section "Toc and subsections"
+
+----
+
+About the global TOC
+--------------------
+
+The global TOC includes sections and subsections.
+
+The max-toc-level parameter allows the user to limit the number of subsections included in the global TOC.
+
+----
+
 Other features
 ==============
 
 View other features in the help sidebar by pressing ``h``
+
+

--- a/src/darkslide/parser.py
+++ b/src/darkslide/parser.py
@@ -23,6 +23,7 @@ class Parser(object):
             r'', re.UNICODE),
         (r'<h(\d+?).*?>', r'<h\1>', re.DOTALL | re.UNICODE),
         (r'<hr.*?>\n', r'<hr />\n', re.DOTALL | re.UNICODE),
+        (r'<a class=\"toc-backref\" href=\"#id[0-9]+\">(.+)<\/a>', r'\1', re.UNICODE),
     ]
 
     md_extensions = ''


### PR DESCRIPTION
Hi,
I corrected a bug when a TOC is inserted in a slide. The resulting code includes an additional backref link to handle the local TOC (this is due to the conversion from RST to HTML). Then, a TOC ref appears to be:

`<a href="...#slide:xx"> <a href="....#id:yy"> My title </a> </a>`

The #id link is generated by the rsttohtml converter and is useless in our case. The #slide:xx link is generated by generator.py. The link is then broken, because of the double link <a><a>.
I filtered the html output with a regex, as done for other useless html things. It works well.