### PR TITLE
fix image URL regex

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Upcoming release (XXX-XX-XX)
+============================
+
+* Fixed a small bug in the image embedding feature (image detection in CSS file
+  could fail)
+
+
 Darkslide v5.0.1 (2019-10-01)
 =============================
 

--- a/src/darkslide/generator.py
+++ b/src/darkslide/generator.py
@@ -516,9 +516,11 @@ class Generator(object):
         html = template.render(context)
 
         if self.embed:
-            images = re.findall(r'url\(["\']?(.*?\.(?:jpe?g|gif|png|svg)[\'"]?)\)', html, re.DOTALL | re.UNICODE)
+            all_urls = re.findall(r'url\([\"\']?(.*?)[\"\']?\)', html, re.DOTALL | re.UNICODE)
+            img_exts = ('.jpg', '.jpeg', '.png', '.gif', '.svg')
+            img_urls = (url for url in all_urls if url.endswith(img_exts))
 
-            for img_url in images:
+            for img_url in img_urls:
                 img_url = img_url.replace('"', '').replace("'", '')
                 if self.theme_dir:
                     source = os.path.join(self.theme_dir, 'css')


### PR DESCRIPTION
The regex used to identify images was faulty, in case another `url()` expression for a non-image file came before in the CSS. 

E.g. in the following case:

```css
@font-face {
  font-family: "MyFont";
  src: url("./path/to/font.woff"); /* (A) */
}
/* ... */
body {
  background: url("./path/to/img.png") /* (B) */
}
```

the regex would match _everything from (A) to (B)_.

This patch fixes the issue.