### PR TITLE
Add wide16x9 theme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -233,6 +233,10 @@ Options:
                         available: no (no line numbers); inline (inside <pre>
                         tag); table (lines numbers in another cell, copy-paste
                         friendly).
+  -m LEVEL, --max-toc-level=LEVEL
+                        Limits the TOC level generation to a specific level.
+  -M, --mod=MOD
+                        Specify a theme modifier by name. Available: wide16x9.
   -o, --direct-output   Prints the generated HTML code to stdout.
   -P, --no-presenter-notes
                         Don't include presenter notes in the output.
@@ -241,7 +245,7 @@ Options:
                         working dir; This may be useful if you intend to
                         publish your html presentation online.
   -t THEME, --theme=THEME
-                        A theme name, or path to a landlside theme directory
+                        A theme name, or path to a daskslide theme directory
   -v, --verbose         Write informational messages to stdout (enabled by
                         default).
   -x EXTENSIONS, --extensions=EXTENSIONS

--- a/README.rst
+++ b/README.rst
@@ -245,7 +245,7 @@ Options:
                         working dir; This may be useful if you intend to
                         publish your html presentation online.
   -t THEME, --theme=THEME
-                        A theme name, or path to a daskslide theme directory
+                        A theme name, or path to a darkslide theme directory
   -v, --verbose         Write informational messages to stdout (enabled by
                         default).
   -x EXTENSIONS, --extensions=EXTENSIONS

--- a/README.rst
+++ b/README.rst
@@ -451,6 +451,15 @@ one by passing the ``--copy-theme`` option to the ``darkslide`` command:
 
     $ darkslide slides.md -t /path/to/some/theme --copy-theme
 
+Widescreen 16x9
+---------------
+
+You can create widescreen 16x9 slides using the ``--mod=wide16x9`` option.
+
+**NOTE:** The ``--mod=wide16x9`` option causes the files in Darkslide's ``themes/wide16x9/``
+directory to supersede the corresponding files in Darkslide's ``themes/default/``
+directory before the selected theme (if any) is applied.
+
 User stylesheets and Javascripts
 ================================
 

--- a/examples/markdown/slides.md
+++ b/examples/markdown/slides.md
@@ -1,6 +1,6 @@
 # Title Slide
 
-.footer: [default theme](.) | [abyss theme](abyss.html) | [void theme](void.html) | [white theme](white.html) | [github](https://github.com/ionelmc/python-darkslide)
+.footer: [default theme](index.html) | [wide16x9 theme](wide16x9.html) | [abyss theme](abyss.html) | [void theme](void.html) | [white theme](white.html) | [github](https://github.com/ionelmc/python-darkslide)
 
 ---
 

--- a/src/darkslide/cli.py
+++ b/src/darkslide/cli.py
@@ -71,6 +71,12 @@ def _parse_options():
         default=2)
 
     parser.add_option(
+        "-M", "--mod",
+        dest="theme_mod",
+        help="Specify a theme modifier by name. Available: wide_16x9.",
+        default='')
+
+    parser.add_option(
         "-o", "--direct-output",
         action="store_true",
         dest="direct",
@@ -105,12 +111,6 @@ def _parse_options():
         "-t", "--theme",
         dest="theme",
         help="A theme name, or path to a landlside theme directory",
-        default='default')
-
-    parser.add_option(
-        "-B", "--base",
-        dest="theme_base",
-        help="Theme base. 'default' or 'wide_6x9'.",
         default='default')
 
     parser.add_option(

--- a/src/darkslide/generator.py
+++ b/src/darkslide/generator.py
@@ -53,7 +53,7 @@ class Generator(object):
             - ``presenter_notes``: enable presenter notes
             - ``relative``: enable relative asset urls
             - ``theme``: path to the theme to use for this presentation
-            - ``theme_base``: Default theme base. Either 'default' or 'wide_6x9'.
+            - ``theme_mod``: modifications to the default theme
             - ``verbose``: enables verbose output
         """
         self.user_css = []
@@ -71,7 +71,7 @@ class Generator(object):
         self.presenter_notes = kwargs.get('presenter_notes', True)
         self.relative = kwargs.get('relative', False)
         self.theme = kwargs.get('theme', 'default')
-        self.theme_base = kwargs.get('theme_base', 'default')
+        self.theme_mod = kwargs.get('theme_mod', '')
         self.verbose = kwargs.get('verbose', False)
         self.linenos = self.linenos_check(kwargs.get('linenos'))
         self.watch = kwargs.get('watch', False)
@@ -270,18 +270,18 @@ class Generator(object):
         return theme_dir
 
     def load_css(self, css_name):
-        """ Load a CSS file from the theme with fallback to theme_base, then to default.
+        """ Load a CSS file from the theme with fallback to theme_mod, then to default.
         """
         css_filename = css_name + '.css'
 
         # Look in theme directory
         css_path = os.path.join(self.theme_dir, 'css', css_filename)
         if self.theme == 'default' or not os.path.exists(css_path):
-            # Fall back to theme_base directory (if specified)
-            if self.theme_base != 'default':
-                css_path = os.path.join(THEMES_DIR, self.theme_base, 'css', css_filename)
-            # Fall back to default directory 
-            if self.theme_base == 'default' or not os.path.exists(css_path):
+            # Fall back to theme_mod directory (if specified)
+            if self.theme_mod:
+                css_path = os.path.join(THEMES_DIR, self.theme_mod, 'css', css_filename)
+            # Fall back to default directory
+            if not self.theme_mod or not os.path.exists(css_path):
                 css_path = os.path.join(THEMES_DIR, 'default', 'css', css_filename)
             if not os.path.exists(css_path):
                 raise IOError(u"Cannot find {} in default theme".format(css_filename))

--- a/src/darkslide/themes/wide16x9/css/base.css
+++ b/src/darkslide/themes/wide16x9/css/base.css
@@ -1,0 +1,159 @@
+h1, h2, h3, h4, h5, h6,
+p, body, header {
+    padding: 0;
+    margin: 0;
+}
+
+.slide {
+    position: relative;
+    overflow: hidden;
+    width: 1333px;
+    height: 750px;
+    border-radius: 20px;
+    -moz-border-radius: 20px;
+    -webkit-border-radius: 20px;
+}
+
+p.hr {
+    height: 0px;
+    font-size: 0px !important;
+    display: block;
+    border-bottom: 1px solid #fdf6e3;
+}
+header:not(:only-child) {
+    font-size: 58px;
+    position: absolute;
+    left: 30px;
+    top: 25px;
+    margin: 0;
+    padding: 0;
+}
+header h1, header h2, header h3, header h4, header h5, header h6 {
+    display: inline;
+    font-size: 110%;
+    font-weight: bold;
+    padding: 0;
+    margin: 0;
+}
+header h2:first-child {
+    margin-top: 0;
+}
+footer {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    padding: 5px;
+    text-align: center;
+}
+section, .slide header:only-child h1 {
+    margin-left: 30px;
+    margin-right: 30px;
+    margin-top: 100px;
+    display: block;
+    overflow: hidden;
+}
+section {
+    font-size: 32px;
+    position: absolute;
+    margin: 0;
+    left: 30px;
+    right: 30px;
+    top: 110px;
+    bottom: 30px;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+}
+section > * {
+    overflow: hidden;
+}
+
+section img.align-center {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}
+section img.align-right {
+    display: block;
+    margin-left: auto;
+    margin-right: 0;
+}
+section img.align-left {
+    display: block;
+    margin-right: auto;
+    margin-left: 0;
+}
+a {
+    text-decoration: none;
+    line-height: 110%;
+}
+ul {
+    margin: 0;
+}
+pre, code, tt {
+    font-family: Consolas, 'Bitstream Vera Sans Mono', 'Lucida Console', FreeMono, Courier, monospace;
+}
+pre, .gist .gist-file .gist-data {
+    font-size: 22px;
+    max-height: 485px;
+    padding: 0 0.5em !important;
+    margin: 0;
+    overflow: auto;
+}
+li {
+    padding: 10px 0;
+}
+li pre {
+    margin: 0;
+}
+.slide header:only-child h1 {
+    line-height: 180%;
+    text-align: center;
+    display: table-cell;
+    vertical-align: middle;
+    height: 750px;
+    width: 1333px;
+    font-size: 68px;
+    margin-top: 100px;
+    margin-bottom: 100px;
+}
+aside {
+    display: none;
+}
+aside.source {
+    position: absolute;
+    bottom: 6px;
+    left: 10px;
+}
+aside.page_number {
+    position: absolute;
+    bottom: 6px;
+    right: 10px;
+    text-indent: 10px;
+}
+.slide p.notes {
+    font-size: 90%;
+}
+img {
+    display: block;
+    margin: 0 auto;
+}
+.center {
+    align-self: center;
+    display: inline-block;
+}
+.large {
+    font-size: 120%;
+}
+.huge {
+    font-size: 150%;
+}
+.qr svg {
+    background: white;
+    max-height: 100%;
+}
+.qr {
+    text-align: center;
+}

--- a/src/darkslide/themes/wide16x9/css/print.css
+++ b/src/darkslide/themes/wide16x9/css/print.css
@@ -1,0 +1,47 @@
+#toc,
+#help,
+.slide aside,
+.slide .notes,
+.presenter_notes,
+#current_presenter_notes,
+#presenter_note {
+    display: none;
+}
+
+@page {
+    margin: 0;
+    size: 1364px 781px;
+}
+.slide,
+.slide.current,
+.slides,
+body,
+.presentation {
+    position: relative;
+    margin: 0;
+    box-shadow: none !important;
+}
+
+.inner {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+.slide {
+    margin: 0 !important;
+    page-break-after: avoid;
+}
+
+.slide-wrapper {
+    page-break-after: always;
+    position: relative;
+    margin: 0;
+    padding: 15px;
+}
+* {
+    -webkit-print-color-adjust: exact;
+    color-adjust: exact;
+}

--- a/src/darkslide/themes/wide16x9/css/screen.css
+++ b/src/darkslide/themes/wide16x9/css/screen.css
@@ -1,0 +1,288 @@
+html, body {
+    overflow: hidden;
+    position: relative;
+    width: 100%;
+    height: 100%;
+}
+.slides .slide {
+    opacity: 0;
+}
+.presenter_view .slide,
+.expose .slide,
+.slide.current,
+.show_next .slide.next {
+    opacity: 1;
+}
+.presentation,
+.presenter_view #current_presenter_notes section,
+.slides,
+.expose .slides,
+.presenter_notes {
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    position: absolute;
+    display: block;
+    background: inherit;
+}
+.slide {
+    position: absolute;
+    display: none;
+    left: 50%;
+    top: 50%;
+    margin-top: -375px;
+    margin-left: -667px;
+    -webkit-transition: margin 0.5s ease-in, opacity 0.5s ease-in;
+    -moz-transition: margin 0.5s ease-in, opacity 0.5s ease-in;
+    -o-transition: margin 0.5s ease-in, opacity 0.5s ease-in;
+}
+.slide.current,
+.slide.prev,
+.slide.next,
+.slide.next_1,
+.slide.next_2 {
+    display: block;
+}
+.slide.prev_1,
+.slide.next_2 {
+    opacity: 0;
+}
+.slide.prev_1 {
+    margin-left: -1525px;
+}
+.slide.prev {
+    margin-left: -1510px;
+}
+.slide.next {
+    margin-left: 677px;
+}
+.slide.next_2 {
+    margin-left: 1368px;
+}
+.slide.next_1 {
+    margin-left: 2020px;
+}
+.show_next .slide.prev {
+    margin-left: -2681px;
+}
+.show_next .slide.current {
+    margin-left: -1338px;
+}
+.show_next .slide.next {
+    margin-left: 5px;
+}
+.show_next .slide.next_1 {
+    margin-left: 1348px;
+}
+/* Content */
+
+/* render a nice scrollbar in overflowed pre area's */
+::-webkit-scrollbar-thumb {
+    background: -webkit-gradient(linear, left bottom, left top, from(#eee), to(#fefefe));
+    border: 1px solid #888;
+    -webkit-border-radius: 1ex;
+}
+::-webkit-scrollbar-corner {
+    background: #dedede;
+}
+::-webkit-scrollbar {
+    height: 8px;
+    width: 8px;
+    background: #888;
+    border-radius: 5px;
+}
+.sidebar {
+    background: white;
+    color: black;
+    border-right: 5px solid #ccc;
+    z-index: 9999999;
+    height: 100%;
+    overflow: hidden;
+    top: 0;
+    position: absolute;
+    display: block;
+    margin: 0;
+    margin-left: -400px;
+    padding: 10px 16px;
+    overflow: auto;
+    -webkit-transition: margin 0.2s ease-in;
+    -moz-transition: margin 0.2s ease-in;
+    -o-transition: margin 0.2s ease-in;
+}
+.sidebar h2 {
+    text-shadow: rgba(0, 0, 0, 0.2) 0 2px 5px;
+    margin: 0 0 16px;
+    padding: 0;
+}
+.sidebar table {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+    border-collapse: collapse;
+}
+.sidebar table caption {
+    display: none;
+}
+.sidebar tr {
+    margin: 2px 0;
+    border-bottom: 1px solid #ccc;
+}
+.sidebar tr:last-of-type {
+    border-bottom: none;
+}
+.sidebar th {
+    text-align: left;
+    font-weight: normal;
+    max-width: 300px;
+    overflow: hidden;
+}
+.sidebar tr.sub th {
+    text-indent: 20px;
+}
+.sidebar td {
+    text-align: right;
+    min-width: 20px;
+}
+.sidebar a, .sidebar a:hover {
+    display: block;
+    text-decoration: none !important;
+    text-shadow: none !important;
+    background: none !important;
+    border-bottom: none;
+    padding: 4px 0;
+}
+.sidebar tr.active {
+    background: #ff0;
+}
+.notes {
+    display: none;
+    padding: 10px;
+    background: #ccc;
+    border-radius: 10px;
+    -moz-border-radius: 10px;
+    -webkit-border-radius: 10px;
+}
+
+/* Expose */
+.expose .slides {
+    overflow: auto;
+}
+.expose .slide {
+    display: block;
+    opacity: 1;
+    float: left;
+    position: relative;
+    left: auto !important;
+    top: auto !important;
+    margin: 10px !important;
+    -webkit-transition: none;
+    -moz-transition: none;
+    -o-transition: none;
+    -moz-transform: scale(.30, .30);
+    -moz-transform-origin: 0 0;
+    -webkit-transform: scale(.30, .30);
+    -webkit-transform-origin: 0 0;
+    -o-transform: scale(.30, .30);
+    -o-transform-origin: 0 0;
+    -webkit-transition: none;
+    -moz-transition: none;
+    -o-transition: none;
+    cursor: pointer;
+}
+.expose .slide-wrapper {
+    float: left;
+    position: relative;
+    margin: 1%;
+    width: 414px;
+    height: 233px;
+}
+.expose .slide footer {
+}
+.expose .slide .inner {
+}
+.expose .slide.next,
+.expose .slide.next_1 {
+    margin-left: 0;
+}
+/* Presenter Mode */
+
+.presenter_view .slide {
+    display: inline;
+    position: absolute;
+    overflow: hidden;
+    -moz-transform: scale(.5, .5);
+    -moz-transform-origin: 0 0;
+    -webkit-transform: scale(.5, .5);
+    -webkit-transform-origin: 0 0;
+    -o-transform: scale(.5, .5);
+    -o-transform-origin: 0 0;
+    margin-top: -375px;
+}
+.presenter_view .slide.prev {
+    display: block;
+    margin-left: -1348px;
+}
+.presenter_view .slide.current {
+    display: block;
+    margin-left: -667px;
+    box-shadow: 0 0 0 15px maroon;
+    z-index: 2;
+}
+.presenter_view .slide.next {
+    display: block;
+    margin-left: 15px;
+    z-index: 1;
+}
+.presenter_view .slide.next_1 {
+    display: block;
+    margin-left: 692px;
+}
+.presenter_view .slide.none {
+    display: none;
+}
+.presenter_view #current_presenter_notes {
+    visibility: visible;
+    display: block;
+    position: fixed;
+    overflow: auto;
+    vertical-align: middle;
+    left: 50%;
+    top: 50%;
+    bottom: 0;
+    margin-left: -475px;
+    margin-top: 20px;
+    z-index: 2;
+    width: 950px;
+    border-radius: 10px;
+    margin-bottom: 20px;
+}
+.presenter_view #current_presenter_notes section {
+    display: block;
+    overflow: visible;
+    margin: 60px 30px 0 30px;
+    font-size: 22px;
+}
+.presenter_view #current_presenter_notes section p {
+    margin: 0;
+}
+.presenter_view #current_presenter_notes h1 {
+    font-size: 50%;
+    display: block;
+}
+#current_presenter_notes {
+    display: none;
+}
+.slide .presenter_notes {
+    display: none;
+}
+#blank {
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-color: black;
+    width: 100%;
+    height: 100%;
+    z-index: 64;
+    display: none;
+}

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,7 @@ commands =
     examples: darkslide --verbose --debug {posargs:--embed} --theme=void examples/config-file/presentation.cfg --destination=dist/examples/void.html
     examples: darkslide --verbose --debug {posargs:--embed} --theme=abyss examples/config-file/presentation.cfg --destination=dist/examples/abyss.html
     examples: darkslide --verbose --debug {posargs:--embed} --theme=white examples/config-file/presentation.cfg --destination=dist/examples/white.html
+    examples: darkslide --verbose --debug {posargs:--embed} --theme=wide16x9 examples/config-file/presentation.cfg --destination=dist/examples/wide16x9.html
 
 [testenv:examples]
 usedevelop = true

--- a/tox.ini
+++ b/tox.ini
@@ -55,10 +55,10 @@ commands =
     examples: darkslide --verbose --debug {posargs:--embed} --theme=void examples/config-file/presentation.cfg --destination=dist/examples/void.html
     examples: darkslide --verbose --debug {posargs:--embed} --theme=abyss examples/config-file/presentation.cfg --destination=dist/examples/abyss.html
     examples: darkslide --verbose --debug {posargs:--embed} --theme=white examples/config-file/presentation.cfg --destination=dist/examples/white.html
-    examples: darkslide --verbose --debug {posargs:--embed} --base=wide16x9 examples/config-file/presentation.cfg --destination=dist/examples/default_wide16x9.html
-    examples: darkslide --verbose --debug {posargs:--embed} --base=wide16x9 --theme=void examples/config-file/presentation.cfg --destination=dist/examples/void_wide16x9.html
-    examples: darkslide --verbose --debug {posargs:--embed} --base=wide16x9 --theme=abyss examples/config-file/presentation.cfg --destination=dist/examples/abyss_wide16x9.html
-    examples: darkslide --verbose --debug {posargs:--embed} --base=wide16x9 --theme=white examples/config-file/presentation.cfg --destination=dist/examples/white_wide16x9.html
+    examples: darkslide --verbose --debug {posargs:--embed} --mod=wide16x9 examples/config-file/presentation.cfg --destination=dist/examples/default_wide16x9.html
+    examples: darkslide --verbose --debug {posargs:--embed} --mod=wide16x9 --theme=void examples/config-file/presentation.cfg --destination=dist/examples/void_wide16x9.html
+    examples: darkslide --verbose --debug {posargs:--embed} --mod=wide16x9 --theme=abyss examples/config-file/presentation.cfg --destination=dist/examples/abyss_wide16x9.html
+    examples: darkslide --verbose --debug {posargs:--embed} --mod=wide16x9 --theme=white examples/config-file/presentation.cfg --destination=dist/examples/white_wide16x9.html
 
 [testenv:examples]
 usedevelop = true


### PR DESCRIPTION
Adds a wide16x9 theme per issue #11.

- Expose and Presenter Mode have both been updated to support the wide format.
- "Next Slide" mode ("c"), and "Notes" mode ("2")  have both been updated to support the wide format.
- I added a new wide16x9.html deck to the tox build, and added it to the footer so that all the decks have navigation links to each other.

Tox did not run without error for me (before the change), but it does run enough to generate the example slide decks (in `dist/examples/`).  It runs as well now (post-change) as it did for me before (pre-change) :)

Note: I changed the "default  theme" link in the slide footer from `.` to `index.html` so that the link to the default theme would work when opening the example deck files locally in a browser (rather than browsing them from a web server).  I believe the `index.html` supports both cases.

I've been using this new theme (with some local style customizations) to develop a complex~30+ slide deck with lots of content/images/etc and it has behaved robustly.

Default:
![default](https://user-images.githubusercontent.com/136718/79481829-d9a4df80-7fc4-11ea-992a-98b6cf0092d6.png)

Wide:
![wide](https://user-images.githubusercontent.com/136718/79481934-fc36f880-7fc4-11ea-94a1-cb28099d8a7f.png)

Wide Expose:
![wide_expose](https://user-images.githubusercontent.com/136718/79482071-22f52f00-7fc5-11ea-87c4-bccb288a8561.png)

Wide  Presenter:
![wide_presenter](https://user-images.githubusercontent.com/136718/79482151-41f3c100-7fc5-11ea-962d-4c327f92e6ae.png)

Wide Next Slide:
![wide_next](https://user-images.githubusercontent.com/136718/79482228-6485da00-7fc5-11ea-989a-b4c01e431fd1.png)

Wide Notes:
![wide_notes](https://user-images.githubusercontent.com/136718/79482323-8a12e380-7fc5-11ea-90e3-ac9cac9a58e3.png)
