### PR TITLE
Adding Power support(ppc64le) with ci and testing to the project for architecture independent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,19 @@ matrix:
         - TOXENV=pypy3,codecov,coveralls
         - TOXPYTHON=pypy3
       python: 'pypy3'
+    - env:
+        - TOXENV=py27,codecov,coveralls
+      python: '2.7'
+      arch: ppc64le
+    - env:
+        - TOXENV=py37,codecov,coveralls
+      python: '3.7'
+      arch: ppc64le
+    - env:
+        - TOXENV=py38,codecov,coveralls
+      python: '3.8'
+      arch: ppc64le
+      
 before_install:
   - |
     if [[ "${TOXENV}" =~ "publish" ]]; then


### PR DESCRIPTION
I am working for IBM to port cpu arch ppc64le for open sources and raised PR to port ppc on this package.

This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro
on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date.

This helps us simplify testing later when distributions are re-building and re-releasing,We typically build applications for customers and ISVs, and while we don't use this package directly, we do count on all of the packages in debian/ubuntu to build other packages. So we more likely have this as a second or third level dependency and couldn't tell you explicitly which features we use or our usage model.

Please help to verify and merge.