### PR TITLE
Remove optional * from postMessage to remove CodeQL warning

### DIFF
--- a/src/darkslide/themes/default/js/slides.js
+++ b/src/darkslide/themes/default/js/slides.js
@@ -164,7 +164,7 @@ function main() {
         }
 
         var w = isPresenterView ? window.opener : presenterViewWin;
-        if (w) w.postMessage('slide#' + currentSlideNo, '*');
+        if (w) w.postMessage('slide#' + currentSlideNo);
     };
 
     var nextSlide = function () {


### PR DESCRIPTION
Missing origin check is being picked up by github CodeQL. The target window is not a data url so * is not required according to https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage